### PR TITLE
Correctly handles content-type header with parameters

### DIFF
--- a/src/SergeiM.Http/Wire/HttpWire.cs
+++ b/src/SergeiM.Http/Wire/HttpWire.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
+using System.Net.Http.Headers;
+
 namespace SergeiM.Http.Wire;
 
 /// <summary>
@@ -44,7 +46,7 @@ public class HttpWire : IWire
         if (body != null)
         {
             request.Content = contentType != null
-                ? new StringContent(body, System.Text.Encoding.UTF8, contentType)
+                ? new StringContent(body, System.Text.Encoding.UTF8, MediaTypeHeaderValue.Parse(contentType))
                 : new StringContent(body);
         }
         return await _client.SendAsync(request);


### PR DESCRIPTION
Closes #7 

This pull request adds comprehensive test coverage for handling various `Content-Type` header scenarios in asynchronous HTTP requests and improves how the content type is set in the `HttpWire` implementation. The most important changes are grouped by theme below.

**Testing improvements:**

* Added three new unit tests in `WireTestBase.cs` to verify that `SendAsync` correctly sets the `Content-Type` header for bare media types, media types with charset parameters, and media types with action parameters. These tests ensure robust handling of different content type formats.

**Implementation improvements:**

* Updated `HttpWire.cs` to use `MediaTypeHeaderValue.Parse(contentType)` when setting the content type for request bodies, allowing proper parsing and handling of complex content type headers with parameters.
* Added `using System.Net.Http.Headers;` to `HttpWire.cs` to support parsing content type headers with parameters.