### PR TITLE
feat(#10): switch to NuGet trusted publishing (OIDC, keyless)

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -16,6 +16,8 @@ name: Publish to NuGet
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,6 +38,11 @@ jobs:
       - name: Pack
         run: dotnet pack --configuration Release --no-build --output ./nupkg
         working-directory: ./src
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ vars.NUGET_USER }}
       - name: Publish to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         working-directory: ./src


### PR DESCRIPTION
Close #10 

This pull request updates the NuGet publishing workflow to improve security by switching from a static API key to OpenID Connect (OIDC) authentication for publishing packages. The workflow now uses the `NuGet/login` action to obtain a temporary API key at publish time.

Security improvements in NuGet publishing workflow:

* Added `id-token: write` permission to the publish job to enable OIDC authentication for secure credential exchange.
* Integrated the `NuGet/login` GitHub Action to obtain a temporary API key via OIDC, replacing the use of a static secret. The publish step now uses this temporary API key for pushing packages to NuGet.