### PR TITLE
Configure build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,396 @@
+root = true
+
+# All files
+[*]
+indent_style = space:warning
+indent_size = 4:warning
+trim_trailing_whitespace = true:warning
+insert_final_newline = true:warning
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# Xml project files
+[*.{csproj,fsproj,vbproj,proj,slnx}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+tab_width = 4
+
+# New line preferences
+insert_final_newline = true:warning
+
+#### .NET Coding Conventions ####
+[*.{cs,vb}]
+
+# Organize usings
+dotnet_separate_import_directive_groups = true:warning
+dotnet_sort_system_directives_first = true:warning
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+#### C# Coding Conventions ####
+[*.cs]
+
+# var preferences
+csharp_style_var_elsewhere = false:warning
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order = public,private,protected,internal,file,const,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:warning
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_throw_expression = true:warning
+csharp_style_unused_value_assignment_preference = discard_variable:warning
+csharp_style_unused_value_expression_statement_preference = discard_variable:warning
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+dotnet_diagnostic.IDE0051.severity = warning
+dotnet_diagnostic.IDE0052.severity = warning
+dotnet_diagnostic.IDE0059.severity = warning
+
+#### Naming styles ####
+[*.{cs,vb}]
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = warning
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style = ipascalcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = suggestion
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style = tpascalcase
+
+dotnet_naming_rule.methods_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.methods_should_be_pascalcase.symbols = methods
+dotnet_naming_rule.methods_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.properties_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.properties_should_be_pascalcase.symbols = properties
+dotnet_naming_rule.properties_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.events_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.events_should_be_pascalcase.symbols = events
+dotnet_naming_rule.events_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style = camelcase
+
+dotnet_naming_rule.local_constants_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.local_constants_should_be_camelcase.symbols = local_constants
+dotnet_naming_rule.local_constants_should_be_camelcase.style = camelcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style = camelcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style = _camelcase
+
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.severity = suggestion
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.style = s_camelcase
+
+dotnet_naming_rule.public_constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_constant_fields_should_be_pascalcase.symbols = public_constant_fields
+dotnet_naming_rule.public_constant_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.private_constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.private_constant_fields_should_be_pascalcase.symbols = private_constant_fields
+dotnet_naming_rule.private_constant_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.symbols = public_static_readonly_fields
+dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.symbols = private_static_readonly_fields
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.enums_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.enums_should_be_pascalcase.symbols = enums
+dotnet_naming_rule.enums_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.local_functions_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascalcase.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers = 
+
+dotnet_naming_symbols.enums.applicable_kinds = enum
+dotnet_naming_symbols.enums.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.enums.required_modifiers = 
+
+dotnet_naming_symbols.events.applicable_kinds = event
+dotnet_naming_symbols.events.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.events.required_modifiers = 
+
+dotnet_naming_symbols.methods.applicable_kinds = method
+dotnet_naming_symbols.methods.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.methods.required_modifiers = 
+
+dotnet_naming_symbols.properties.applicable_kinds = property
+dotnet_naming_symbols.properties.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.properties.required_modifiers = 
+
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers = 
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers = 
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+dotnet_naming_symbols.type_parameters.applicable_kinds = namespace
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers = 
+
+dotnet_naming_symbols.private_constant_fields.applicable_kinds = field
+dotnet_naming_symbols.private_constant_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_constant_fields.required_modifiers = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers = 
+
+dotnet_naming_symbols.local_constants.applicable_kinds = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers = const
+
+dotnet_naming_symbols.parameters.applicable_kinds = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers = 
+
+dotnet_naming_symbols.public_constant_fields.applicable_kinds = field
+dotnet_naming_symbols.public_constant_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_constant_fields.required_modifiers = const
+
+dotnet_naming_symbols.public_static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.public_static_readonly_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_readonly_fields.required_modifiers = readonly, static
+
+dotnet_naming_symbols.private_static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_static_readonly_fields.required_modifiers = readonly, static
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = *
+dotnet_naming_symbols.local_functions.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix = 
+dotnet_naming_style.pascalcase.required_suffix = 
+dotnet_naming_style.pascalcase.word_separator = 
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix = 
+dotnet_naming_style.ipascalcase.word_separator = 
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix = 
+dotnet_naming_style.tpascalcase.word_separator = 
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix = 
+dotnet_naming_style._camelcase.word_separator = 
+dotnet_naming_style._camelcase.capitalization = camel_case
+
+dotnet_naming_style.camelcase.required_prefix = 
+dotnet_naming_style.camelcase.required_suffix = 
+dotnet_naming_style.camelcase.word_separator = 
+dotnet_naming_style.camelcase.capitalization = camel_case
+
+dotnet_naming_style.s_camelcase.required_prefix = s_
+dotnet_naming_style.s_camelcase.required_suffix = 
+dotnet_naming_style.s_camelcase.word_separator = 
+dotnet_naming_style.s_camelcase.capitalization = camel_case
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 name: Build and Test
 "on":
   push:
@@ -17,7 +18,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Restore dependencies
         run: dotnet restore --locked-mode
         working-directory: ./src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
-      - name: Check code formatting
-        run: dotnet format --verify-no-changes --verbosity diagnostic
-        working-directory: ./src
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore --locked-mode
+        working-directory: ./src
+      - name: Check code formatting
+        run: dotnet format --no-restore --verify-no-changes --verbosity diagnostic
         working-directory: ./src
       - name: Build
         run: dotnet build --no-restore --configuration Release

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Restore dependencies
         run: dotnet restore --locked-mode
         working-directory: ./src

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           dotnet-version: "8.0.x"
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore --locked-mode
         working-directory: ./src
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,11 +12,13 @@ path = [
   ".markdownlint-cli2.yaml",
   "release-please-config.json",
   ".release-please-manifest.json",
+  ".editorconfig",
   "**.md",
   "**/*.runsettings",
   "**/*.props",
   "**/*.csproj",
-  "**/*.sln"
+  "**/*.sln",
+  "**/*.lock.json"
 ]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright (c) [2025-2026] [Sergei Mukhin]"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project>
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    </PropertyGroup>
-    <PropertyGroup>
-        <VersionPrefix>0.5.0</VersionPrefix>
-        <VersionSuffix/>
-    </PropertyGroup>
-    <PropertyGroup>
-        <SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildThisFileDirectory)</SolutionDir>
-        <ArtifactsPath>$(SolutionDir).artifacts\</ArtifactsPath>
-        <PublishDir>$(SolutionDir).artifacts\publish\</PublishDir>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionSuffix />
+  </PropertyGroup>
+  <PropertyGroup>
+    <SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildThisFileDirectory)</SolutionDir>
+    <ArtifactsPath>$(SolutionDir).artifacts\</ArtifactsPath>
+    <PublishDir>$(SolutionDir).artifacts\publish\</PublishDir>
+  </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     </PropertyGroup>
     <PropertyGroup>
         <VersionPrefix>0.5.0</VersionPrefix>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,13 +2,20 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="SergeiM.Json" Version="0.2.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk"
+                    Version="17.6.0" />
+    <PackageVersion Include="MSTest.TestAdapter"
+                    Version="3.0.4" />
+    <PackageVersion Include="MSTest.TestFramework"
+                    Version="3.0.4" />
+    <PackageVersion Include="coverlet.collector"
+                    Version="6.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub"
+                    Version="8.0.0" />
+    <PackageVersion Include="SergeiM.Json"
+                    Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/src/SergeiM.Http.Tests/JsonResponseTests.cs
+++ b/src/SergeiM.Http.Tests/JsonResponseTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using SergeiM.Http.Response;
+using SergeiM.Json;
 
 namespace SergeiM.Http.Tests;
 
@@ -11,12 +12,12 @@ public class JsonResponseTests
     [TestMethod]
     public void JsonResponse_ShouldParseJsonObject()
     {
-        var json = """{"name": "John Doe", "age": 30, "active": true}""";
+        string json = """{"name": "John Doe", "age": 30, "active": true}""";
         var response = new JsonResponse(CreateMockJsonResponse(json));
-        var obj = response.AsObject();
-        var name = obj.GetString("name");
-        var age = obj.GetInt("age");
-        var active = obj.GetBoolean("active");
+        JsonObject obj = response.AsObject();
+        string name = obj.GetString("name");
+        int age = obj.GetInt("age");
+        bool active = obj.GetBoolean("active");
         Assert.AreEqual("John Doe", name);
         Assert.AreEqual(30, age);
         Assert.AreEqual(true, active);
@@ -25,20 +26,20 @@ public class JsonResponseTests
     [TestMethod]
     public void JsonResponse_ShouldAccessNestedProperties()
     {
-        var json = @"{""user"": {""name"": ""Jane"", ""email"": ""jane@example.com""}}";
+        string json = @"{""user"": {""name"": ""Jane"", ""email"": ""jane@example.com""}}";
         var response = new JsonResponse(CreateMockJsonResponse(json));
-        var obj = response.AsObject();
-        var name = obj.GetJsonObject("user")!.GetString("name");
+        JsonObject obj = response.AsObject();
+        string name = obj.GetJsonObject("user")!.GetString("name");
         Assert.AreEqual("Jane", name);
     }
 
     [TestMethod]
     public void JsonArray_ShouldAccessElements()
     {
-        var json = @"{""items"": [""apple"", ""banana"", ""cherry""]}";
+        string json = @"{""items"": [""apple"", ""banana"", ""cherry""]}";
         var response = new JsonResponse(CreateMockJsonResponse(json));
-        var obj = response.AsObject();
-        var items = obj.GetJsonArray("items")!;
+        JsonObject obj = response.AsObject();
+        JsonArray items = obj.GetJsonArray("items")!;
         Assert.AreEqual(3, items.Count);
         Assert.AreEqual("apple", items.GetString(0));
         Assert.AreEqual("banana", items.GetString(1));
@@ -47,19 +48,19 @@ public class JsonResponseTests
     [TestMethod]
     public void JsonResponse_AssertStatus_ShouldReturnJsonResponse()
     {
-        var json = @"{""result"": ""success""}";
+        string json = @"{""result"": ""success""}";
         var response = new JsonResponse(CreateMockJsonResponse(json));
-        var result = response.AssertStatus(200).AsObject();
+        JsonObject result = response.AssertStatus(200).AsObject();
         Assert.AreEqual("success", result.GetString("result"));
     }
 
     [TestMethod]
     public void JsonResponse_AssertStatus_AfterAs_ShouldAllowChaining()
     {
-        var json = @"{""value"": 42}";
-        var httpResponse = CreateMockJsonResponse(json);
+        string json = @"{""value"": 42}";
+        HttpResponseMessage httpResponse = CreateMockJsonResponse(json);
         var baseResponse = new BaseResponse(httpResponse);
-        var result = baseResponse.As<JsonResponse>().AssertStatus(200).AsObject();
+        JsonObject result = baseResponse.As<JsonResponse>().AssertStatus(200).AsObject();
         Assert.AreEqual(42, result.GetInt("value"));
     }
 

--- a/src/SergeiM.Http.Tests/RequestTests.cs
+++ b/src/SergeiM.Http.Tests/RequestTests.cs
@@ -11,14 +11,14 @@ public class RequestTests
     [TestMethod]
     public void Request_ShouldBuildSimpleUri()
     {
-        var uri = new BaseRequest("https://www.example.com:8080").Uri().Path("/users").QueryParam("id", 333).Build();
+        string uri = new BaseRequest("https://www.example.com:8080").Uri().Path("/users").QueryParam("id", 333).Build();
         Assert.AreEqual("https://www.example.com:8080/users?id=333", uri);
     }
 
     [TestMethod]
     public void Request_ShouldSetMethod()
     {
-        var request = new BaseRequest("https://www.example.com")
+        IRequest request = new BaseRequest("https://www.example.com")
             .Method(BaseRequest.POST);
         Assert.IsNotNull(request);
     }
@@ -26,7 +26,7 @@ public class RequestTests
     [TestMethod]
     public void Request_ShouldSetHeaders()
     {
-        var request = new BaseRequest("https://www.example.com")
+        IRequest request = new BaseRequest("https://www.example.com")
             .Header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
             .Header(HttpHeaders.USER_AGENT, "FluentHttp/1.0");
         Assert.IsNotNull(request);
@@ -35,7 +35,7 @@ public class RequestTests
     [TestMethod]
     public void UriBuilder_ShouldHandleMultipleQueryParams()
     {
-        var uri = new BaseRequest("https://api.example.com").Uri()
+        string uri = new BaseRequest("https://api.example.com").Uri()
             .Path("/search")
             .QueryParam("q", "test")
             .QueryParam("page", 1)
@@ -50,7 +50,7 @@ public class RequestTests
     public void UriBuilder_ShouldReturnNewRequest()
     {
         var request = new BaseRequest("https://www.example.com");
-        var back = request.Uri().Path("/test").Back();
+        IRequest back = request.Uri().Path("/test").Back();
         Assert.AreNotSame(request, back);
     }
 
@@ -58,7 +58,7 @@ public class RequestTests
     public void WithUri_ShouldReturnNewRequest()
     {
         var request = new BaseRequest("https://www.example.com");
-        var newRequest = request.WithUri("https://api.example.com");
+        IRequest newRequest = request.WithUri("https://api.example.com");
         Assert.IsNotNull(newRequest);
         Assert.AreNotSame(request, newRequest);
     }
@@ -66,7 +66,7 @@ public class RequestTests
     [TestMethod]
     public void WithUri_ShouldAllowFurtherUriBuilding()
     {
-        var uri = new BaseRequest("https://old.example.com")
+        string uri = new BaseRequest("https://old.example.com")
             .WithUri("https://new.example.com")
             .Uri()
             .Path("/api")

--- a/src/SergeiM.Http.Tests/SergeiM.Http.Tests.csproj
+++ b/src/SergeiM.Http.Tests/SergeiM.Http.Tests.csproj
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)\.runsettings</RunSettingsFilePath>

--- a/src/SergeiM.Http.Tests/SergeiM.Http.Tests.csproj
+++ b/src/SergeiM.Http.Tests/SergeiM.Http.Tests.csproj
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-        <RunSettingsFilePath>$(MSBuildThisFileDirectory)\.runsettings</RunSettingsFilePath>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="MSTest.TestAdapter" />
-        <PackageReference Include="MSTest.TestFramework" />
-        <PackageReference Include="coverlet.collector" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\SergeiM.Http\SergeiM.Http.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)\.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SergeiM.Http\SergeiM.Http.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/SergeiM.Http.Tests/Wire/BasicAuthWireTests.cs
+++ b/src/SergeiM.Http.Tests/Wire/BasicAuthWireTests.cs
@@ -19,7 +19,7 @@ public class BasicAuthWireTests
             receivedHeaders = headers;
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new BasicAuthWire(
+        HttpResponseMessage response = await new BasicAuthWire(
             mockWire,
             "Bearer test-token").SendAsync("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -38,8 +38,8 @@ public class BasicAuthWireTests
         {
             ["X-Custom"] = "Value"
         };
-        var originalCount = headers.Count;
-        await new BasicAuthWire(
+        int originalCount = headers.Count;
+        _ = await new BasicAuthWire(
             mockWire,
             "Bearer test-token").SendAsync("GET", "https://api.example.com", headers);
         Assert.AreEqual(originalCount, headers.Count);
@@ -54,7 +54,7 @@ public class BasicAuthWireTests
             Assert.IsTrue(request.Headers.Contains("X-Custom"));
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var response = await new BasicAuthWire(
+        HttpResponseMessage response = await new BasicAuthWire(
             new HttpWire(new HttpClient(handler)),
             "Bearer test-token").SendAsync("GET", "https://api.example.com", new Dictionary<string, string>
             {
@@ -68,11 +68,11 @@ public class BasicAuthWireTests
     {
         var handler = new MockHttpMessageHandler(async (request) =>
         {
-            var body = await request.Content!.ReadAsStringAsync();
+            string body = await request.Content!.ReadAsStringAsync();
             Assert.AreEqual("{\"data\":\"test\"}", body);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var response = await new BasicAuthWire(
+        HttpResponseMessage response = await new BasicAuthWire(
             new HttpWire(new HttpClient(handler)),
             "Bearer test-token").SendAsync("POST", "https://api.example.com", [], "{\"data\":\"test\"}");
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);

--- a/src/SergeiM.Http.Tests/Wire/RetryWireTests.cs
+++ b/src/SergeiM.Http.Tests/Wire/RetryWireTests.cs
@@ -13,13 +13,13 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldReturnOnFirstSuccess()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -30,7 +30,7 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldRetryOnServerError()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -40,7 +40,7 @@ public class RetryWireTests
             }
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -51,7 +51,7 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldRetryOnTooManyRequests()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -61,7 +61,7 @@ public class RetryWireTests
             }
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -72,13 +72,13 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldNotRetryOnClientError()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -89,13 +89,13 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldRespectMaxRetries()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             2,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -106,7 +106,7 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldRetryOnHttpRequestException()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -116,7 +116,7 @@ public class RetryWireTests
             }
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -127,15 +127,15 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldThrowAfterMaxRetriesOnException()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
             throw new HttpRequestException("Network error");
         });
-        await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        _ = await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
         {
-            await new RetryWire(
+            _ = await new RetryWire(
                 mockWire,
                 2,
                 TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -146,7 +146,7 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldUseCustomRetryLogic()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -156,7 +156,7 @@ public class RetryWireTests
             }
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10),
@@ -179,7 +179,7 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldRetryOnTaskCanceledException()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -189,7 +189,7 @@ public class RetryWireTests
             }
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);
@@ -200,7 +200,7 @@ public class RetryWireTests
     [TestMethod]
     public async Task SendAsync_ShouldRetryOnTimeoutException()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -210,7 +210,7 @@ public class RetryWireTests
             }
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         });
-        var response = await new RetryWire(
+        HttpResponseMessage response = await new RetryWire(
             mockWire,
             3,
             TimeSpan.FromMilliseconds(10)).SendAsync("GET", "https://api.example.com", []);

--- a/src/SergeiM.Http.Tests/Wire/WireDecoratorChainTests.cs
+++ b/src/SergeiM.Http.Tests/Wire/WireDecoratorChainTests.cs
@@ -26,14 +26,14 @@ public class WireDecoratorChainTests
             ),
             "Bearer test-token"
         );
-        var response = await wire.SendAsync("GET", "https://api.example.com", []);
+        HttpResponseMessage response = await wire.SendAsync("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     }
 
     [TestMethod]
     public async Task ShouldRetryWithAuthorization()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -49,7 +49,7 @@ public class WireDecoratorChainTests
             3,
             TimeSpan.FromMilliseconds(10)
         );
-        var response = await wire.SendAsync("GET", "https://api.example.com", []);
+        HttpResponseMessage response = await wire.SendAsync("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         Assert.AreEqual(2, attemptCount);
     }
@@ -57,7 +57,7 @@ public class WireDecoratorChainTests
     [TestMethod]
     public async Task ShouldChainInReverseOrder()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -72,7 +72,7 @@ public class WireDecoratorChainTests
             new RetryWire(mockWire, 3, TimeSpan.FromMilliseconds(10)),
             "Bearer test-token"
         );
-        var response = await wire.SendAsync("GET", "https://api.example.com", []);
+        HttpResponseMessage response = await wire.SendAsync("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         Assert.AreEqual(2, attemptCount);
     }
@@ -80,7 +80,7 @@ public class WireDecoratorChainTests
     [TestMethod]
     public async Task ShouldChainMultipleRetryDecorators()
     {
-        var attemptCount = 0;
+        int attemptCount = 0;
         var mockWire = new MockWire((method, uri, headers, body) =>
         {
             attemptCount++;
@@ -95,7 +95,7 @@ public class WireDecoratorChainTests
             1,
             TimeSpan.FromMilliseconds(5)
         );
-        var response = await wire.SendAsync("GET", "https://api.example.com", []);
+        HttpResponseMessage response = await wire.SendAsync("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     }
 }

--- a/src/SergeiM.Http.Tests/Wire/WireTestBase.cs
+++ b/src/SergeiM.Http.Tests/Wire/WireTestBase.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using System.Net;
+using System.Net.Http.Headers;
 using SergeiM.Http.Tests.Wire.Mocks;
 
 namespace SergeiM.Http.Tests.Wire;
@@ -25,9 +26,9 @@ public abstract class WireTestBase
                 Content = new StringContent("Success")
             };
         });
-        var response = await CreateWire(new HttpClient(handler)).SendAsync("GET", "https://api.example.com/test", []);
+        HttpResponseMessage response = await CreateWire(new HttpClient(handler)).SendAsync("GET", "https://api.example.com/test", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-        var content = await response.Content.ReadAsStringAsync();
+        string content = await response.Content.ReadAsStringAsync();
         Assert.AreEqual("Success", content);
     }
 
@@ -40,7 +41,7 @@ public abstract class WireTestBase
             Assert.AreEqual("CustomValue", request.Headers.GetValues("X-Custom-Header").First());
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var response = await CreateWire(new HttpClient(handler)).SendAsync("GET", "https://api.example.com", new Dictionary<string, string>
+        HttpResponseMessage response = await CreateWire(new HttpClient(handler)).SendAsync("GET", "https://api.example.com", new Dictionary<string, string>
         {
             ["X-Custom-Header"] = "CustomValue"
         });
@@ -52,11 +53,11 @@ public abstract class WireTestBase
     {
         var handler = new MockHttpMessageHandler(async (request) =>
         {
-            var body = await request.Content!.ReadAsStringAsync();
+            string body = await request.Content!.ReadAsStringAsync();
             Assert.AreEqual("{\"test\":\"data\"}", body);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var response = await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", [], "{\"test\":\"data\"}");
+        HttpResponseMessage response = await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", [], "{\"test\":\"data\"}");
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -67,7 +68,7 @@ public abstract class WireTestBase
         {
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        var response = CreateWire(new HttpClient(handler)).Send("GET", "https://api.example.com", []);
+        HttpResponseMessage response = CreateWire(new HttpClient(handler)).Send("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     }
 
@@ -76,11 +77,11 @@ public abstract class WireTestBase
     {
         var handler = new MockHttpMessageHandler((request) =>
         {
-            var ct = request.Content!.Headers.ContentType;
+            MediaTypeHeaderValue? ct = request.Content!.Headers.ContentType;
             Assert.AreEqual("application/json", ct!.MediaType);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", new Dictionary<string, string>
+        _ = await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", new Dictionary<string, string>
         {
             ["Content-Type"] = "application/json"
         }, "{\"test\":\"data\"}");
@@ -91,12 +92,12 @@ public abstract class WireTestBase
     {
         var handler = new MockHttpMessageHandler((request) =>
         {
-            var ct = request.Content!.Headers.ContentType;
+            MediaTypeHeaderValue? ct = request.Content!.Headers.ContentType;
             Assert.AreEqual("text/xml", ct!.MediaType);
             Assert.AreEqual("utf-8", ct.CharSet);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", new Dictionary<string, string>
+        _ = await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", new Dictionary<string, string>
         {
             ["Content-Type"] = "text/xml; charset=utf-8"
         }, "<root/>");
@@ -108,14 +109,14 @@ public abstract class WireTestBase
         const string soapAction = "http://example.com/MyService/MyAction";
         var handler = new MockHttpMessageHandler((request) =>
         {
-            var ct = request.Content!.Headers.ContentType;
+            MediaTypeHeaderValue? ct = request.Content!.Headers.ContentType;
             Assert.AreEqual("application/soap+xml", ct!.MediaType);
-            var actionParam = ct.Parameters.FirstOrDefault(p => p.Name == "action");
+            NameValueHeaderValue? actionParam = ct.Parameters.FirstOrDefault(p => p.Name == "action");
             Assert.IsNotNull(actionParam);
             Assert.AreEqual($"\"{soapAction}\"", actionParam.Value);
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
-        await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", new Dictionary<string, string>
+        _ = await CreateWire(new HttpClient(handler)).SendAsync("POST", "https://api.example.com", new Dictionary<string, string>
         {
             ["Content-Type"] = $"application/soap+xml; action=\"{soapAction}\""
         }, "<Envelope/>");

--- a/src/SergeiM.Http.Tests/XmlResponseTests.cs
+++ b/src/SergeiM.Http.Tests/XmlResponseTests.cs
@@ -12,7 +12,7 @@ public class XmlResponseTests
     [TestMethod]
     public void XmlResponse_ShouldParseXml()
     {
-        var xml = """
+        string xml = """
             <?xml version="1.0"?>
             <page>
                 <title>Test Page</title>
@@ -22,14 +22,14 @@ public class XmlResponseTests
                 </links>
             </page>
             """;
-        var title = new XmlResponse(CreateMockXmlResponse(xml)).EvaluateXPath("/page/title");
+        string title = new XmlResponse(CreateMockXmlResponse(xml)).EvaluateXPath("/page/title");
         Assert.AreEqual("Test Page", title);
     }
 
     [TestMethod]
     public void XmlResponse_ShouldAssertXPath()
     {
-        var xml = """
+        string xml = """
             <?xml version="1.0"?>
             <page>
                 <links>
@@ -37,26 +37,26 @@ public class XmlResponseTests
                 </links>
             </page>
             """;
-        new XmlResponse(CreateMockXmlResponse(xml)).AssertXPath("/page/links/link[@rel='see']");
+        _ = new XmlResponse(CreateMockXmlResponse(xml)).AssertXPath("/page/links/link[@rel='see']");
     }
 
     [TestMethod]
     [ExpectedException(typeof(InvalidOperationException))]
     public void XmlResponse_ShouldThrowOnMissingXPath()
     {
-        var xml = """
+        string xml = """
             <?xml version="1.0"?>
             <page>
                 <title>Test</title>
             </page>
             """;
-        new XmlResponse(CreateMockXmlResponse(xml)).AssertXPath("/page/nonexistent");
+        _ = new XmlResponse(CreateMockXmlResponse(xml)).AssertXPath("/page/nonexistent");
     }
 
     [TestMethod]
     public void XmlResponse_ShouldEvaluateXPathAttribute()
     {
-        var xml = """
+        string xml = """
             <?xml version="1.0"?>
             <page>
                 <links>
@@ -64,32 +64,32 @@ public class XmlResponseTests
                 </links>
             </page>
             """;
-        var href = new XmlResponse(CreateMockXmlResponse(xml)).EvaluateXPath("/page/links/link[@rel='see']/@href");
+        string href = new XmlResponse(CreateMockXmlResponse(xml)).EvaluateXPath("/page/links/link[@rel='see']/@href");
         Assert.AreEqual("/api/details/456", href);
     }
 
     [TestMethod]
     public void XmlResponse_AssertStatus_ShouldReturnXmlResponse()
     {
-        var xml = """
+        string xml = """
             <?xml version="1.0"?>
             <result>success</result>
             """;
         var response = new XmlResponse(CreateMockXmlResponse(xml));
-        var result = response.AssertStatus(200).EvaluateXPath("/result");
+        string result = response.AssertStatus(200).EvaluateXPath("/result");
         Assert.AreEqual("success", result);
     }
 
     [TestMethod]
     public void XmlResponse_AssertStatus_AfterAs_ShouldAllowChaining()
     {
-        var xml = """
+        string xml = """
             <?xml version="1.0"?>
             <data><value>test</value></data>
             """;
-        var httpResponse = CreateMockXmlResponse(xml);
+        HttpResponseMessage httpResponse = CreateMockXmlResponse(xml);
         var baseResponse = new BaseResponse(httpResponse);
-        var result = baseResponse.As<XmlResponse>().AssertStatus(200).EvaluateXPath("/data/value");
+        string result = baseResponse.As<XmlResponse>().AssertStatus(200).EvaluateXPath("/data/value");
         Assert.AreEqual("test", result);
     }
 

--- a/src/SergeiM.Http.Tests/packages.lock.json
+++ b/src/SergeiM.Http.Tests/packages.lock.json
@@ -1,0 +1,85 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net8.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.6.0, )",
+        "resolved": "17.6.0",
+        "contentHash": "tHyg4C6c89QvLv6Utz3xKlba4EeoyJyIz59Q1NrjRENV7gfGnSE6I+sYPIbVOzQttoo2zpHDgOK/p6Hw2OlD7A==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.6.0",
+          "Microsoft.TestPlatform.TestHost": "17.6.0"
+        }
+      },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "18THEGVcU4fbAOZWvRtEyvQCnZ/o+3LFAiFbAkWYh63GC5TmHoJ10IUiF9L02SMmbLbWpH1/PxvO7mcInIY4/Q=="
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "hYq5xOOr2k09rtXpmcHkJ4Tdt/yS4cy8jiFPNMdDJP+lB6OY8yekOmQC4Fsvug4rhLpXGDd6zbPWYeoewqfePA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.6.0",
+        "contentHash": "5v2GwzpR7JEuQUzupjx3zLwn2FutADW/weLzLt726DR3WXxsM+ICPoJG6pxuKFsumtZp890UrVuudTUhsE8Qyg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.6.0",
+        "contentHash": "AA/rrf5zwC5/OBLEOajkhjbVTM3SvxRXy8kcQ8e4mJKojbyZvqqhpfNg362N9vXU94DLg9NUTFOAnoYVT0pTJw==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.6.0",
+        "contentHash": "7YdgUcIeCPVKLC7n7LNKDiEHWc7z3brkkYPdUbDnFsvf6WvY9UfzS0VSUJ8P2NgN0CDSD223GCJFSjSBLZRqOQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.6.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "sergeim.http": {
+        "type": "Project",
+        "dependencies": {
+          "SergeiM.Json": "[0.2.0, )"
+        }
+      },
+      "SergeiM.Json": {
+        "type": "CentralTransitive",
+        "requested": "[0.2.0, )",
+        "resolved": "0.2.0",
+        "contentHash": "L2CDDr4UOuDIIYI58y4Xyb5sqAXH1HI7DcnC6qbkuZHtzyAtKdXet1Xyl2W96a4om4NxHDrl0z+nczwU0gkavQ=="
+      }
+    }
+  }
+}

--- a/src/SergeiM.Http.Tests/packages.lock.json
+++ b/src/SergeiM.Http.Tests/packages.lock.json
@@ -1,6 +1,80 @@
 {
   "version": 2,
   "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.6.0, )",
+        "resolved": "17.6.0",
+        "contentHash": "tHyg4C6c89QvLv6Utz3xKlba4EeoyJyIz59Q1NrjRENV7gfGnSE6I+sYPIbVOzQttoo2zpHDgOK/p6Hw2OlD7A==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.6.0",
+          "Microsoft.TestPlatform.TestHost": "17.6.0"
+        }
+      },
+      "MSTest.TestAdapter": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "18THEGVcU4fbAOZWvRtEyvQCnZ/o+3LFAiFbAkWYh63GC5TmHoJ10IUiF9L02SMmbLbWpH1/PxvO7mcInIY4/Q=="
+      },
+      "MSTest.TestFramework": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "hYq5xOOr2k09rtXpmcHkJ4Tdt/yS4cy8jiFPNMdDJP+lB6OY8yekOmQC4Fsvug4rhLpXGDd6zbPWYeoewqfePA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.6.0",
+        "contentHash": "5v2GwzpR7JEuQUzupjx3zLwn2FutADW/weLzLt726DR3WXxsM+ICPoJG6pxuKFsumtZp890UrVuudTUhsE8Qyg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.6.0",
+        "contentHash": "AA/rrf5zwC5/OBLEOajkhjbVTM3SvxRXy8kcQ8e4mJKojbyZvqqhpfNg362N9vXU94DLg9NUTFOAnoYVT0pTJw==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.6.0",
+        "contentHash": "7YdgUcIeCPVKLC7n7LNKDiEHWc7z3brkkYPdUbDnFsvf6WvY9UfzS0VSUJ8P2NgN0CDSD223GCJFSjSBLZRqOQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.6.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "sergeim.http": {
+        "type": "Project",
+        "dependencies": {
+          "SergeiM.Json": "[0.2.0, )"
+        }
+      },
+      "SergeiM.Json": {
+        "type": "CentralTransitive",
+        "requested": "[0.2.0, )",
+        "resolved": "0.2.0",
+        "contentHash": "L2CDDr4UOuDIIYI58y4Xyb5sqAXH1HI7DcnC6qbkuZHtzyAtKdXet1Xyl2W96a4om4NxHDrl0z+nczwU0gkavQ=="
+      }
+    },
     "net8.0": {
       "coverlet.collector": {
         "type": "Direct",
@@ -40,8 +114,7 @@
         "resolved": "17.6.0",
         "contentHash": "AA/rrf5zwC5/OBLEOajkhjbVTM3SvxRXy8kcQ8e4mJKojbyZvqqhpfNg362N9vXU94DLg9NUTFOAnoYVT0pTJw==",
         "dependencies": {
-          "NuGet.Frameworks": "5.11.0",
-          "System.Reflection.Metadata": "1.6.0"
+          "NuGet.Frameworks": "5.11.0"
         }
       },
       "Microsoft.TestPlatform.TestHost": {
@@ -62,11 +135,6 @@
         "type": "Transitive",
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
-      },
-      "System.Reflection.Metadata": {
-        "type": "Transitive",
-        "resolved": "1.6.0",
-        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
       },
       "sergeim.http": {
         "type": "Project",

--- a/src/SergeiM.Http/IRequest.cs
+++ b/src/SergeiM.Http/IRequest.cs
@@ -15,7 +15,7 @@ public interface IRequest
     /// </summary>
     /// <param name="body">The body content to send with the request.</param>
     /// <returns>The new request instance with the updated body content.</returns>
-    IRequest Body(string body);
+    public IRequest Body(string body);
 
     /// <summary>
     /// Sets the request body content with a specific Content-Type.
@@ -23,7 +23,7 @@ public interface IRequest
     /// <param name="body">The body content to send with the request.</param>
     /// <param name="contentType">The Content-Type header value (e.g., "application/json").</param>
     /// <returns>The new request instance with the updated body content and content type.</returns>
-    IRequest Body(string body, string contentType);
+    public IRequest Body(string body, string contentType);
 
     /// <summary>
     /// Sets the request body as JSON by serializing the provided object.
@@ -31,19 +31,19 @@ public interface IRequest
     /// </summary>
     /// <param name="obj">The object to serialize as JSON.</param>
     /// <returns>The new request instance with the updated body content.</returns>
-    IRequest JsonBody(object obj);
+    public IRequest JsonBody(object obj);
 
     /// <summary>
     /// Executes the HTTP request synchronously and returns the response.
     /// </summary>
     /// <returns>The HTTP response.</returns>
-    BaseResponse Fetch();
+    public BaseResponse Fetch();
 
     /// <summary>
     /// Executes the HTTP request asynchronously and returns the response.
     /// </summary>
     /// <returns>A task that represents the asynchronous operation. The task result contains the HTTP response.</returns>
-    Task<BaseResponse> FetchAsync();
+    public Task<BaseResponse> FetchAsync();
 
     /// <summary>
     /// Adds or updates an HTTP header for the request.
@@ -51,14 +51,14 @@ public interface IRequest
     /// <param name="name">The header name.</param>
     /// <param name="value">The header value.</param>
     /// <returns>The new request instance with the updated header.</returns>
-    IRequest Header(string name, string value);
+    public IRequest Header(string name, string value);
 
     /// <summary>
     /// Sets the HTTP method for the request (GET, POST, PUT, DELETE, etc.).
     /// </summary>
     /// <param name="method">The HTTP method to use.</param>
     /// <returns>The new request instance with the updated HTTP method.</returns>
-    IRequest Method(string method);
+    public IRequest Method(string method);
 
     /// <summary>
     /// Changes the wire implementation used to send the request.
@@ -66,18 +66,18 @@ public interface IRequest
     /// </summary>
     /// <param name="wire">The wire implementation to use for sending the request.</param>
     /// <returns>The new request instance with the updated wire implementation.</returns>
-    IRequest Through(IWire wire);
+    public IRequest Through(IWire wire);
 
     /// <summary>
     /// Gets the URI builder for constructing the request URI with path segments and query parameters.
     /// </summary>
     /// <returns>A URI builder instance for fluent URI construction.</returns>
-    IUriBuilder Uri();
+    public IUriBuilder Uri();
 
     /// <summary>
     /// Creates a new request with a different base URI while preserving other state.
     /// </summary>
     /// <param name="uri">The new base URI.</param>
     /// <returns>A new request instance with the updated URI.</returns>
-    IRequest WithUri(string uri);
+    public IRequest WithUri(string uri);
 }

--- a/src/SergeiM.Http/IResponse.cs
+++ b/src/SergeiM.Http/IResponse.cs
@@ -11,19 +11,19 @@ public interface IResponse
     /// <summary>
     /// Gets the HTTP status code of the response.
     /// </summary>
-    int StatusCode { get; }
+    public int StatusCode { get; }
 
     /// <summary>
     /// Gets the response body content as a string.
     /// </summary>
-    string Content { get; }
+    public string Content { get; }
 
     /// <summary>
     /// Converts this response to a specific response type for specialized processing (e.g., JSON, XML).
     /// </summary>
     /// <typeparam name="T">The target response type that implements IResponse.</typeparam>
     /// <returns>The response converted to the specified type.</returns>
-    T As<T>() where T : IResponse;
+    public T As<T>() where T : IResponse;
 
     /// <summary>
     /// Asserts that the response has the expected status code.
@@ -31,14 +31,14 @@ public interface IResponse
     /// <param name="expectedStatus">The expected HTTP status code.</param>
     /// <returns>The current response instance for method chaining.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the actual status code doesn't match the expected value.</exception>
-    IResponse AssertStatus(int expectedStatus);
+    public IResponse AssertStatus(int expectedStatus);
 
     /// <summary>
     /// Retrieves the value of a specific response header.
     /// </summary>
     /// <param name="name">The header name to retrieve.</param>
     /// <returns>The header value, or null if the header doesn't exist.</returns>
-    string? GetHeader(string name);
+    public string? GetHeader(string name);
 
     /// <summary>
     /// Creates a new request with the specified header, using the same base URI as the current response.
@@ -46,7 +46,7 @@ public interface IResponse
     /// <param name="name">The header name to add to the new request.</param>
     /// <param name="value">The header value to add to the new request.</param>
     /// <returns>A new request instance with the specified header.</returns>
-    IRequest Header(string name, string value);
+    public IRequest Header(string name, string value);
 
     /// <summary>
     /// Creates a new request following a relative URI from the response.
@@ -54,5 +54,5 @@ public interface IResponse
     /// </summary>
     /// <param name="href">The relative URI to follow.</param>
     /// <returns>A new request instance for the specified URI.</returns>
-    IRequest Rel(string href);
+    public IRequest Rel(string href);
 }

--- a/src/SergeiM.Http/IUriBuilder.cs
+++ b/src/SergeiM.Http/IUriBuilder.cs
@@ -12,20 +12,20 @@ public interface IUriBuilder
     /// Returns to the parent request builder.
     /// </summary>
     /// <returns>The parent request instance.</returns>
-    IRequest Back();
+    public IRequest Back();
 
     /// <summary>
     /// Builds and returns the complete URI as a string.
     /// </summary>
     /// <returns>The constructed URI.</returns>
-    string Build();
+    public string Build();
 
     /// <summary>
     /// Appends a path segment to the URI.
     /// </summary>
     /// <param name="pathSegment">The path segment to append (e.g., "/users" or "users").</param>
     /// <returns>The current URI builder instance for method chaining.</returns>
-    IUriBuilder Path(string pathSegment);
+    public IUriBuilder Path(string pathSegment);
 
     /// <summary>
     /// Adds a query parameter to the URI.
@@ -33,5 +33,5 @@ public interface IUriBuilder
     /// <param name="name">The query parameter name.</param>
     /// <param name="value">The query parameter value. Will be converted to string and URL-encoded.</param>
     /// <returns>The current URI builder instance for method chaining.</returns>
-    IUriBuilder QueryParam(string name, object value);
+    public IUriBuilder QueryParam(string name, object value);
 }

--- a/src/SergeiM.Http/IWire.cs
+++ b/src/SergeiM.Http/IWire.cs
@@ -17,7 +17,7 @@ public interface IWire
     /// <param name="headers">The request headers</param>
     /// <param name="body">The request body (optional)</param>
     /// <returns>The HTTP response</returns>
-    Task<HttpResponseMessage> SendAsync(string method, string uri, Dictionary<string, string> headers, string? body = null);
+    public Task<HttpResponseMessage> SendAsync(string method, string uri, Dictionary<string, string> headers, string? body = null);
 
     /// <summary>
     /// Sends an HTTP request synchronously.
@@ -27,5 +27,5 @@ public interface IWire
     /// <param name="headers">The request headers</param>
     /// <param name="body">The request body (optional)</param>
     /// <returns>The HTTP response</returns>
-    HttpResponseMessage Send(string method, string uri, Dictionary<string, string> headers, string? body = null);
+    public HttpResponseMessage Send(string method, string uri, Dictionary<string, string> headers, string? body = null);
 }

--- a/src/SergeiM.Http/Request/BaseRequest.cs
+++ b/src/SergeiM.Http/Request/BaseRequest.cs
@@ -158,7 +158,7 @@ public class BaseRequest : IRequest
         {
             headers[HttpHeaders.CONTENT_TYPE] = _contentType;
         }
-        var response = await _wire.SendAsync(_method, _home, headers, _body);
+        HttpResponseMessage response = await _wire.SendAsync(_method, _home, headers, _body);
         return new BaseResponse(response);
     }
 

--- a/src/SergeiM.Http/Response/BaseResponse.cs
+++ b/src/SergeiM.Http/Response/BaseResponse.cs
@@ -57,7 +57,7 @@ public class BaseResponse : IResponse
     /// <inheritdoc/>
     public virtual string? GetHeader(string name)
     {
-        if (_response.Headers.TryGetValues(name, out var values))
+        if (_response.Headers.TryGetValues(name, out IEnumerable<string>? values))
         {
             return values.FirstOrDefault();
         }
@@ -78,10 +78,10 @@ public class BaseResponse : IResponse
         }
 
         // Otherwise, construct it relative to the current request
-        var baseUri = _response.RequestMessage?.RequestUri?.GetLeftPart(UriPartial.Authority)
+        string baseUri = _response.RequestMessage?.RequestUri?.GetLeftPart(UriPartial.Authority)
                       ?? throw new InvalidOperationException("Cannot determine base URI");
 
-        var absoluteUri = new Uri(new Uri(baseUri), href).ToString();
+        string absoluteUri = new Uri(new Uri(baseUri), href).ToString();
         return new BaseRequest(absoluteUri);
     }
 

--- a/src/SergeiM.Http/Response/JsonResponse.cs
+++ b/src/SergeiM.Http/Response/JsonResponse.cs
@@ -90,7 +90,7 @@ public class JsonResponse : BaseResponse
     /// <exception cref="HttpRequestException">Thrown when the actual status code doesn't match the expected value.</exception>
     public new JsonResponse AssertStatus(int expectedStatus)
     {
-        base.AssertStatus(expectedStatus);
+        _ = base.AssertStatus(expectedStatus);
         return this;
     }
 }

--- a/src/SergeiM.Http/Response/XmlResponse.cs
+++ b/src/SergeiM.Http/Response/XmlResponse.cs
@@ -65,7 +65,7 @@ public class XmlResponse : BaseResponse
     /// </summary>
     public string EvaluateXPath(string xpath)
     {
-        var result = Navigator.Evaluate(xpath);
+        object result = Navigator.Evaluate(xpath);
         if (result is XPathNodeIterator iterator)
         {
             if (iterator.MoveNext())
@@ -80,7 +80,7 @@ public class XmlResponse : BaseResponse
     /// <inheritdoc/>
     public override IRequest Rel(string xpath)
     {
-        var href = EvaluateXPath(xpath);
+        string href = EvaluateXPath(xpath);
         return base.Rel(href);
     }
 
@@ -92,7 +92,7 @@ public class XmlResponse : BaseResponse
     /// <exception cref="HttpRequestException">Thrown when the actual status code doesn't match the expected value.</exception>
     public new XmlResponse AssertStatus(int expectedStatus)
     {
-        base.AssertStatus(expectedStatus);
+        _ = base.AssertStatus(expectedStatus);
         return this;
     }
 }

--- a/src/SergeiM.Http/SergeiM.Http.csproj
+++ b/src/SergeiM.Http/SergeiM.Http.csproj
@@ -1,36 +1,39 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <!-- Package Metadata -->
-        <PackageId>SergeiM.Http</PackageId>
-        <Title>SergeiM.Http</Title>
-        <Description>A fluent HTTP client library for .NET that provides a pure OOP approach to building and executing HTTP requests with method chaining. Supports wire decorators for authorization, retries, and custom request handling.</Description>
-        <Authors>Sergei Mukhin</Authors>
-        <Company>Sergei Mukhin</Company>
-        <Copyright>Copyright © 2025 Sergei Mukhin</Copyright>
-        <!-- Package Details -->
-        <PackageTags>http;fluent;rest;api;client;http-client;rest-client;fluent-api;wire;decorator</PackageTags>
-        <PackageProjectUrl>https://github.com/svmukhin/sergeim-http</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/svmukhin/sergeim-http</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <!-- Release Notes -->
-        <PackageReleaseNotes>See release notes at: https://github.com/svmukhin/sergeim-http/releases/tag/v$(VersionPrefix)</PackageReleaseNotes>
-        <!-- Source Link -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <!-- Documentation -->
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
-    <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    </ItemGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-        <PackageReference Include="SergeiM.Json" />
-    </ItemGroup>
+  <PropertyGroup>
+    <!-- Package Metadata -->
+    <PackageId>SergeiM.Http</PackageId>
+    <Title>SergeiM.Http</Title>
+    <Description>A fluent HTTP client library for .NET that provides a pure OOP approach to building and executing HTTP requests with method chaining. Supports wire decorators for authorization, retries, and custom request handling.</Description>
+    <Authors>Sergei Mukhin</Authors>
+    <Company>Sergei Mukhin</Company>
+    <Copyright>Copyright © 2025 Sergei Mukhin</Copyright>
+    <!-- Package Details -->
+    <PackageTags>http;fluent;rest;api;client;http-client;rest-client;fluent-api;wire;decorator</PackageTags>
+    <PackageProjectUrl>https://github.com/svmukhin/sergeim-http</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/svmukhin/sergeim-http</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <!-- Release Notes -->
+    <PackageReleaseNotes>See release notes at: https://github.com/svmukhin/sergeim-http/releases/tag/v$(VersionPrefix)</PackageReleaseNotes>
+    <!-- Source Link -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Documentation -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md"
+          Pack="true"
+          PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub"
+                      PrivateAssets="All" />
+    <PackageReference Include="SergeiM.Json" />
+  </ItemGroup>
 </Project>

--- a/src/SergeiM.Http/UriBuilder.cs
+++ b/src/SergeiM.Http/UriBuilder.cs
@@ -23,7 +23,7 @@ public class UriBuilder : IUriBuilder
         BaseUri = $"{uri.Scheme}://{uri.Authority}";
         if (!string.IsNullOrEmpty(uri.AbsolutePath) && uri.AbsolutePath != "/")
         {
-            _path.Append(uri.AbsolutePath);
+            _ = _path.Append(uri.AbsolutePath);
         }
         if (!string.IsNullOrEmpty(uri.Query))
         {
@@ -38,9 +38,9 @@ public class UriBuilder : IUriBuilder
     {
         if (!pathSegment.StartsWith("/"))
         {
-            _path.Append('/');
+            _ = _path.Append('/');
         }
-        _path.Append(pathSegment);
+        _ = _path.Append(pathSegment);
         return this;
     }
 
@@ -63,12 +63,12 @@ public class UriBuilder : IUriBuilder
         var sb = new StringBuilder(BaseUri);
         if (_path.Length > 0)
         {
-            sb.Append(_path);
+            _ = sb.Append(_path);
         }
         if (_queryParams.Count > 0)
         {
-            sb.Append('?');
-            sb.Append(string.Join("&", _queryParams.Select(kvp =>
+            _ = sb.Append('?');
+            _ = sb.Append(string.Join("&", _queryParams.Select(kvp =>
                 $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}")));
         }
         return sb.ToString();
@@ -80,12 +80,12 @@ public class UriBuilder : IUriBuilder
         {
             query = query.Substring(1);
         }
-        var pairs = query.Split('&');
-        foreach (var pair in pairs)
+        string[] pairs = query.Split('&');
+        foreach (string pair in pairs)
         {
-            var parts = pair.Split('=', 2);
-            var key = Uri.UnescapeDataString(parts[0]);
-            var value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1]) : string.Empty;
+            string[] parts = pair.Split('=', 2);
+            string key = Uri.UnescapeDataString(parts[0]);
+            string value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1]) : string.Empty;
             _queryParams[key] = value;
         }
     }

--- a/src/SergeiM.Http/Wire/HttpWire.cs
+++ b/src/SergeiM.Http/Wire/HttpWire.cs
@@ -37,11 +37,11 @@ public class HttpWire : IWire
         if (headersCopy.ContainsKey("Content-Type"))
         {
             contentType = headersCopy["Content-Type"];
-            headersCopy.Remove("Content-Type");
+            _ = headersCopy.Remove("Content-Type");
         }
-        foreach (var header in headersCopy)
+        foreach (KeyValuePair<string, string> header in headersCopy)
         {
-            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            _ = request.Headers.TryAddWithoutValidation(header.Key, header.Value);
         }
         if (body != null)
         {

--- a/src/SergeiM.Http/Wire/RetryWire.cs
+++ b/src/SergeiM.Http/Wire/RetryWire.cs
@@ -51,7 +51,7 @@ public class RetryWire : IWire
         {
             try
             {
-                var response = await _origin.SendAsync(method, uri, headers, body);
+                HttpResponseMessage response = await _origin.SendAsync(method, uri, headers, body);
                 if (attempt < _maxRetries && ShouldRetryResponse(response))
                 {
                     await Task.Delay(_delayBetweenRetries);

--- a/src/SergeiM.Http/packages.lock.json
+++ b/src/SergeiM.Http/packages.lock.json
@@ -1,6 +1,34 @@
 {
   "version": 2,
   "dependencies": {
+    "net10.0": {
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "SergeiM.Json": {
+        "type": "Direct",
+        "requested": "[0.2.0, )",
+        "resolved": "0.2.0",
+        "contentHash": "L2CDDr4UOuDIIYI58y4Xyb5sqAXH1HI7DcnC6qbkuZHtzyAtKdXet1Xyl2W96a4om4NxHDrl0z+nczwU0gkavQ=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      }
+    },
     "net8.0": {
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/SergeiM.Http/packages.lock.json
+++ b/src/SergeiM.Http/packages.lock.json
@@ -1,0 +1,33 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net8.0": {
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "SergeiM.Json": {
+        "type": "Direct",
+        "requested": "[0.2.0, )",
+        "resolved": "0.2.0",
+        "contentHash": "L2CDDr4UOuDIIYI58y4Xyb5sqAXH1HI7DcnC6qbkuZHtzyAtKdXet1Xyl2W96a4om4NxHDrl0z+nczwU0gkavQ=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces several improvements to the project's .NET build, code style enforcement, and test code clarity. The main changes include multi-targeting for .NET 8.0 and 10.0, stricter code style and formatting enforcement, and enhanced type safety in test code. Additionally, a comprehensive `.editorconfig` file has been added to standardize coding conventions across the codebase.

**Build and Target Frameworks:**
- Updated `Directory.Build.props` to target both `net8.0` and `net10.0`, and enabled code style enforcement during build. Also, changed release builds to exclude debug symbols for smaller artifacts.
- Modified CI workflows (`build.yml`, `publish-nuget.yml`) to install and build against both .NET 8.0 and 10.0, and to use locked package restores for reproducibility. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R28) [[2]](diffhunk://#diff-77c07671c6abe25698f92a0b92941c64e012d2e1f0d5f7a982e2b1bbc1ea5e3eL28-R32)

**Code Style and Formatting:**
- Added a detailed `.editorconfig` file to enforce consistent formatting, naming, and code style rules across the repository.
- Enabled code style checks in the build pipeline and improved the `dotnet format` usage for stricter validation. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L20-R28) [[2]](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907L4-R12)

**Dependency Management:**
- Enabled lock file usage for package restores in `Directory.Packages.props` for more reliable dependency management.

**Test Code Improvements:**
- Updated `JsonResponseTests.cs` to explicitly declare variable types, improving code clarity and type safety in tests. [[1]](diffhunk://#diff-d165e4002e0bc45c6c119f7c2a038827addc551199768f1e64b1cd70afc155f9R5) [[2]](diffhunk://#diff-d165e4002e0bc45c6c119f7c2a038827addc551199768f1e64b1cd70afc155f9L14-R20) [[3]](diffhunk://#diff-d165e4002e0bc45c6c119f7c2a038827addc551199768f1e64b1cd70afc155f9L28-R42)

**Other:**
- Added a `yamllint` directive to ignore line length warnings in workflow files for better CI readability.