### PR TITLE
Managed wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,52 @@ var response = new BaseRequest("https://api.example.com")
     .Fetch();
 ```
 
+## HttpClient Lifecycle
+
+The default `new HttpWire()` constructor creates `new HttpClient()` and holds
+it for the wire's lifetime. This is fine for short-lived apps but causes
+**socket exhaustion** and **stale DNS** in long-running server applications.
+
+### Console apps / one-shot scripts
+
+For short-lived processes, a single `HttpClient` instance is all you need:
+
+```csharp
+using var client = new HttpClient { BaseAddress = new Uri("https://api.example.com") };
+var wire = new HttpWire(client);
+var user = await new BaseRequest("/users/1", wire).FetchAsync();
+```
+
+### ASP.NET Core / long-running services
+
+Use `IHttpClientFactory` via `ManagedHttpWire` — it creates and disposes
+an `HttpClient` per request, letting the factory manage handler pooling and DNS
+rotation:
+
+```csharp
+// Program.cs
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<IWire>(sp =>
+    new ManagedHttpWire(() => sp.GetRequiredService<IHttpClientFactory>().CreateClient()));
+```
+
+With a named client for custom settings:
+
+```csharp
+builder.Services.AddHttpClient("github", c =>
+{
+    c.BaseAddress = new Uri("https://api.github.com");
+    c.DefaultRequestHeaders.Add("User-Agent", "MyApp");
+});
+builder.Services.AddSingleton<IWire>(sp =>
+    new ManagedHttpWire(() => sp.GetRequiredService<IHttpClientFactory>().CreateClient("github")));
+```
+
+`ManagedHttpWire` is stateless and can be registered as a **Singleton**.
+
+> **Warning**: Avoid `new HttpWire()` (parameterless) in server applications.
+> It creates an unmanaged `HttpClient` that will exhaust sockets over time.
+
 ## Wire System
 
 SergeiM.Http uses a wire system for sending HTTP requests, allowing
@@ -102,7 +148,8 @@ you to customize and extend request handling through decorators.
 
 ### Basic Wire Usage
 
-By default, requests use `HttpWire`:
+By default, requests use `HttpWire` internally. For long-running applications,
+prefer `ManagedHttpWire` with `IHttpClientFactory` (see [HttpClient Lifecycle](#httpclient-lifecycle)).
 
 ```csharp
 var response = await new BaseRequest("https://api.example.com").FetchAsync();
@@ -113,7 +160,8 @@ var response = await new BaseRequest("https://api.example.com").FetchAsync();
 You can specify a custom wire implementation:
 
 ```csharp
-var response = await new BaseRequest("https://api.example.com", new HttpWire()).FetchAsync();
+var response = await new BaseRequest("https://api.example.com",
+    new ManagedHttpWire(() => new HttpClient())).FetchAsync();
 ```
 
 ### Changing Wire with Through()
@@ -122,7 +170,7 @@ Change the wire at any point using the `Through()` method:
 
 ```csharp
 var response = await new BaseRequest("https://api.example.com")
-    .Through(new HttpWire())
+    .Through(new ManagedHttpWire(() => new HttpClient()))
     .FetchAsync();
 ```
 
@@ -132,7 +180,9 @@ Add authorization headers to requests:
 
 ```csharp
 var response = await new BaseRequest("https://api.example.com")
-    .Through(new BasicAuthWire(new HttpWire(), "Bearer your-token"))
+    .Through(new BasicAuthWire(
+        new ManagedHttpWire(() => new HttpClient()),
+        "Bearer your-token"))
     .FetchAsync();
 ```
 
@@ -142,7 +192,7 @@ Add automatic retry logic for failed requests:
 
 ```csharp
 var response = await new BaseRequest("https://api.example.com", new RetryWire(
-    new HttpWire(),
+    new ManagedHttpWire(() => new HttpClient()),
     maxRetries: 5,
     delayBetweenRetries: TimeSpan.FromSeconds(2)
 )).FetchAsync();
@@ -155,7 +205,7 @@ Combine multiple decorators for advanced functionality:
 ```csharp
 var wire = new RetryWire(
     new BasicAuthWire(
-        new HttpWire(),
+        new ManagedHttpWire(() => new HttpClient()),
         "Bearer token"
     ),
     maxRetries: 3,
@@ -170,10 +220,14 @@ Or fluently with `Through()`:
 
 ```csharp
 var response = await new BaseRequest("https://api.example.com")
-    .Through(new BasicAuthWire(new HttpWire(), "Bearer token"))
+    .Through(new BasicAuthWire(
+        new ManagedHttpWire(() => new HttpClient()),
+        "Bearer token"))
     .Uri().Path("/protected-resource").Back()
     .Through(new RetryWire(
-        new BasicAuthWire(new HttpWire(), "Bearer token"),
+        new BasicAuthWire(
+            new ManagedHttpWire(() => new HttpClient()),
+            "Bearer token"),
         3,
         TimeSpan.FromSeconds(2)
     ))

--- a/src/SergeiM.Http.Tests/Wire/ManagedHttpWireTests.cs
+++ b/src/SergeiM.Http.Tests/Wire/ManagedHttpWireTests.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
+// SPDX-License-Identifier: MIT
+
+using System.Net;
+using SergeiM.Http.Tests.Wire.Mocks;
+using SergeiM.Http.Wire;
+
+namespace SergeiM.Http.Tests.Wire;
+
+[TestClass]
+public class ManagedHttpWireTests : WireTestBase
+{
+    protected override IWire CreateWire(HttpClient client)
+    {
+        return new ManagedHttpWire(() => client);
+    }
+
+    [TestMethod]
+    public void Constructor_ShouldAcceptFactoryDelegate()
+    {
+        var wire = new ManagedHttpWire(() => new HttpClient());
+        Assert.IsNotNull(wire);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_ShouldCreateNewClientPerRequest()
+    {
+        int createCount = 0;
+        var handler = new MockHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var wire = new ManagedHttpWire(() =>
+        {
+            createCount++;
+            return new HttpClient(handler);
+        });
+        _ = await wire.SendAsync("GET", "https://api.example.com", []);
+        _ = await wire.SendAsync("GET", "https://api.example.com", []);
+        Assert.AreEqual(2, createCount);
+    }
+}

--- a/src/SergeiM.Http.Tests/Wire/WireDecoratorChainTests.cs
+++ b/src/SergeiM.Http.Tests/Wire/WireDecoratorChainTests.cs
@@ -98,4 +98,18 @@ public class WireDecoratorChainTests
         HttpResponseMessage response = await wire.SendAsync("GET", "https://api.example.com", []);
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
     }
+
+    [TestMethod]
+    public async Task ShouldChainManagedWireWithBasicAuth()
+    {
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            Assert.IsTrue(request.Headers.Contains(HttpHeaders.AUTHORIZATION));
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var managedWire = new ManagedHttpWire(() => new HttpClient(handler));
+        var wire = new BasicAuthWire(managedWire, "Bearer test-token");
+        HttpResponseMessage response = await wire.SendAsync("GET", "https://api.example.com", []);
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+    }
 }

--- a/src/SergeiM.Http/Wire/HttpWire.cs
+++ b/src/SergeiM.Http/Wire/HttpWire.cs
@@ -30,7 +30,7 @@ public class HttpWire : IWire
     /// <inheritdoc/>
     public async Task<HttpResponseMessage> SendAsync(string method, string uri, Dictionary<string, string> headers, string? body = null)
     {
-        using var request = WireHelper.BuildRequest(method, uri, headers, body);
+        using HttpRequestMessage request = WireHelper.BuildRequest(method, uri, headers, body);
         return await _client.SendAsync(request);
     }
 

--- a/src/SergeiM.Http/Wire/HttpWire.cs
+++ b/src/SergeiM.Http/Wire/HttpWire.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using System.Net.Http.Headers;
-
 namespace SergeiM.Http.Wire;
 
 /// <summary>
@@ -29,26 +27,10 @@ public class HttpWire : IWire
     }
 
     /// <inheritdoc/>
+    /// <inheritdoc/>
     public async Task<HttpResponseMessage> SendAsync(string method, string uri, Dictionary<string, string> headers, string? body = null)
     {
-        using var request = new HttpRequestMessage(new HttpMethod(method), uri);
-        string? contentType = null;
-        var headersCopy = new Dictionary<string, string>(headers);
-        if (headersCopy.ContainsKey("Content-Type"))
-        {
-            contentType = headersCopy["Content-Type"];
-            _ = headersCopy.Remove("Content-Type");
-        }
-        foreach (KeyValuePair<string, string> header in headersCopy)
-        {
-            _ = request.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
-        if (body != null)
-        {
-            request.Content = contentType != null
-                ? new StringContent(body, System.Text.Encoding.UTF8, MediaTypeHeaderValue.Parse(contentType))
-                : new StringContent(body);
-        }
+        using var request = WireHelper.BuildRequest(method, uri, headers, body);
         return await _client.SendAsync(request);
     }
 

--- a/src/SergeiM.Http/Wire/ManagedHttpWire.cs
+++ b/src/SergeiM.Http/Wire/ManagedHttpWire.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
+// SPDX-License-Identifier: MIT
+
+namespace SergeiM.Http.Wire;
+
+/// <summary>
+/// Wire implementation that creates a fresh <see cref="HttpClient"/> from a factory delegate on every request.
+/// Designed for use with <c>IHttpClientFactory</c> in long-running applications.
+/// </summary>
+public class ManagedHttpWire : IWire
+{
+    private readonly Func<HttpClient> _createClient;
+
+    /// <summary>
+    /// Creates a new ManagedHttpWire with a factory delegate that produces <see cref="HttpClient"/> instances.
+    /// </summary>
+    /// <param name="createClient">A delegate that returns a new <see cref="HttpClient"/>. Intended to wrap <c>IHttpClientFactory.CreateClient()</c>.</param>
+    public ManagedHttpWire(Func<HttpClient> createClient)
+    {
+        _createClient = createClient;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> SendAsync(string method, string uri, Dictionary<string, string> headers, string? body = null)
+    {
+        HttpClient client = _createClient();
+        try
+        {
+            using var request = WireHelper.BuildRequest(method, uri, headers, body);
+            return await client.SendAsync(request);
+        }
+        finally
+        {
+            client.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    public HttpResponseMessage Send(string method, string uri, Dictionary<string, string> headers, string? body = null)
+    {
+        return SendAsync(method, uri, headers, body).GetAwaiter().GetResult();
+    }
+}

--- a/src/SergeiM.Http/Wire/ManagedHttpWire.cs
+++ b/src/SergeiM.Http/Wire/ManagedHttpWire.cs
@@ -26,7 +26,7 @@ public class ManagedHttpWire : IWire
         HttpClient client = _createClient();
         try
         {
-            using var request = WireHelper.BuildRequest(method, uri, headers, body);
+            using HttpRequestMessage request = WireHelper.BuildRequest(method, uri, headers, body);
             return await client.SendAsync(request);
         }
         finally

--- a/src/SergeiM.Http/Wire/WireHelper.cs
+++ b/src/SergeiM.Http/Wire/WireHelper.cs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
+// SPDX-License-Identifier: MIT
+
+using System.Net.Http.Headers;
+
+namespace SergeiM.Http.Wire;
+
+internal static class WireHelper
+{
+    internal static HttpRequestMessage BuildRequest(string method, string uri, Dictionary<string, string> headers, string? body)
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), uri);
+        string? contentType = null;
+        var headersCopy = new Dictionary<string, string>(headers);
+        if (headersCopy.ContainsKey("Content-Type"))
+        {
+            contentType = headersCopy["Content-Type"];
+            _ = headersCopy.Remove("Content-Type");
+        }
+        foreach (KeyValuePair<string, string> header in headersCopy)
+        {
+            _ = request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+        if (body != null)
+        {
+            request.Content = contentType != null
+                ? new StringContent(body, System.Text.Encoding.UTF8, MediaTypeHeaderValue.Parse(contentType))
+                : new StringContent(body);
+        }
+        return request;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `ManagedHttpWire` implementation for improved `HttpClient` lifecycle management, especially in long-running applications, and updates the documentation and tests accordingly. It also refactors request construction logic into a shared helper. These changes help prevent socket exhaustion and stale DNS issues in server scenarios.

**New features and improvements:**

* Added `ManagedHttpWire`, a new wire implementation that creates a fresh `HttpClient` per request using a factory delegate, designed for use with `IHttpClientFactory` in long-running applications.
* Introduced `WireHelper.BuildRequest` to centralize and reuse HTTP request construction logic, and updated `HttpWire` and `ManagedHttpWire` to use this helper. [[1]](diffhunk://#diff-b9d5294f989c909203598dae03721a3981fe803208b6552e52b39cb90c643fd7R1-R32) [[2]](diffhunk://#diff-f4b6b6e0b38eade7dbb9ead83aae2c1d26745d8c8896c545bf45d2dab0c0eefeR29-R33)

**Documentation updates:**

* Expanded the `README.md` with a new "HttpClient Lifecycle" section, detailed guidance for both short-lived and long-running apps, and updated all code samples to recommend `ManagedHttpWire` over direct `HttpWire` usage in server scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98-R152) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-R164) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R173) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R185) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-R195) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R208) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L173-R230)

**Testing enhancements:**

* Added `ManagedHttpWireTests` to verify correct client creation and integration with the wire system.
* Added a new test to ensure `ManagedHttpWire` works with decorator chains, such as `BasicAuthWire`.

**Code cleanup:**

* Removed an unused `using System.Net.Http.Headers;` directive from `HttpWire.cs`.