### PR TITLE
fix: add ConfigureAwait(false) to all async calls

### DIFF
--- a/src/SergeiM.Http/Request/BaseRequest.cs
+++ b/src/SergeiM.Http/Request/BaseRequest.cs
@@ -158,7 +158,7 @@ public class BaseRequest : IRequest
         {
             headers[HttpHeaders.CONTENT_TYPE] = _contentType;
         }
-        HttpResponseMessage response = await _wire.SendAsync(_method, _home, headers, _body);
+        HttpResponseMessage response = await _wire.SendAsync(_method, _home, headers, _body).ConfigureAwait(false);
         return new BaseResponse(response);
     }
 

--- a/src/SergeiM.Http/Wire/HttpWire.cs
+++ b/src/SergeiM.Http/Wire/HttpWire.cs
@@ -31,7 +31,7 @@ public class HttpWire : IWire
     public async Task<HttpResponseMessage> SendAsync(string method, string uri, Dictionary<string, string> headers, string? body = null)
     {
         using HttpRequestMessage request = WireHelper.BuildRequest(method, uri, headers, body);
-        return await _client.SendAsync(request);
+        return await _client.SendAsync(request).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/src/SergeiM.Http/Wire/ManagedHttpWire.cs
+++ b/src/SergeiM.Http/Wire/ManagedHttpWire.cs
@@ -27,7 +27,7 @@ public class ManagedHttpWire : IWire
         try
         {
             using HttpRequestMessage request = WireHelper.BuildRequest(method, uri, headers, body);
-            return await client.SendAsync(request);
+            return await client.SendAsync(request).ConfigureAwait(false);
         }
         finally
         {

--- a/src/SergeiM.Http/Wire/RetryWire.cs
+++ b/src/SergeiM.Http/Wire/RetryWire.cs
@@ -51,10 +51,10 @@ public class RetryWire : IWire
         {
             try
             {
-                HttpResponseMessage response = await _origin.SendAsync(method, uri, headers, body);
+                HttpResponseMessage response = await _origin.SendAsync(method, uri, headers, body).ConfigureAwait(false);
                 if (attempt < _maxRetries && ShouldRetryResponse(response))
                 {
-                    await Task.Delay(_delayBetweenRetries);
+                    await Task.Delay(_delayBetweenRetries).ConfigureAwait(false);
                     continue;
                 }
                 return response;
@@ -64,7 +64,7 @@ public class RetryWire : IWire
                 lastException = ex;
                 if (attempt < _maxRetries)
                 {
-                    await Task.Delay(_delayBetweenRetries);
+                    await Task.Delay(_delayBetweenRetries).ConfigureAwait(false);
                 }
                 else
                 {


### PR DESCRIPTION
This pull request improves the handling of asynchronous operations throughout the HTTP request pipeline by consistently applying `.ConfigureAwait(false)` to all `await` calls. This change helps prevent potential deadlocks and ensures that continuations after asynchronous calls do not attempt to marshal back to the original synchronization context, which is especially important for library code.

The most important changes include:

**Async Await Consistency and Reliability:**

* Added `.ConfigureAwait(false)` to all `await` calls in `SendAsync` methods in `HttpWire`, `ManagedHttpWire`, and `RetryWire` classes to ensure proper continuation behavior and avoid deadlocks. [[1]](diffhunk://#diff-f4b6b6e0b38eade7dbb9ead83aae2c1d26745d8c8896c545bf45d2dab0c0eefeL34-R34) [[2]](diffhunk://#diff-a5df6be8ea9030c421610ed563153b0642de39dbd0de5d6944025e0bb64733b5L30-R30) [[3]](diffhunk://#diff-5fae4da4b944197b98e8920b315316498bbfd687f99d6ec5a9513a40798db3a6L54-R57)
* Updated `Task.Delay` calls in `RetryWire` to use `.ConfigureAwait(false)`, ensuring retry delays do not capture the synchronization context. [[1]](diffhunk://#diff-5fae4da4b944197b98e8920b315316498bbfd687f99d6ec5a9513a40798db3a6L54-R57) [[2]](diffhunk://#diff-5fae4da4b944197b98e8920b315316498bbfd687f99d6ec5a9513a40798db3a6L67-R67)
* Modified the `FetchAsync` method in `BaseRequest` to use `.ConfigureAwait(false)` when awaiting HTTP responses, aligning with best practices for library code.

These changes collectively make the library safer and more robust for use in a variety of application types, including those without a synchronization context (such as console apps or background services).