### PR TITLE
fix: added debug symbols to nuget package

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,10 +7,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugType>none</DebugType>
-    <DebugSymbols>false</DebugSymbols>
-  </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix />


### PR DESCRIPTION
This pull request makes a minor change to the project build configuration by removing a property group that disabled debug symbols and debug type in Release builds.

* Removed the `<PropertyGroup>` in `src/Directory.Build.props` that set `<DebugType>none</DebugType>` and `<DebugSymbols>false</DebugSymbols>` for Release builds, allowing debug symbols to be included in Release builds.